### PR TITLE
Implement GUI dashboard flow and 8-byte teleop handling for issue #5

### DIFF
--- a/Client-PC/GUI/README.md
+++ b/Client-PC/GUI/README.md
@@ -1,0 +1,100 @@
+# Client-PC GUI
+
+## What this is
+
+This dashboard is the operator-side GUI for live controller monitoring. It
+understands the same wire protocol used by the Go clients and the Pi server:
+
+```
+[4-byte big-endian length] [JSON payload] [4-byte CRC32]
+```
+
+It can run in two useful modes:
+
+- **Monitor mode**: accept packets and visualize them locally.
+- **Proxy mode**: accept packets, visualize them, and forward them unchanged to
+  the real `Server-Pi/Network-Stack` server.
+
+Proxy mode is the easiest way to test the GUI with the existing repo code,
+because the Go clients keep talking their normal protocol while the dashboard
+shows everything live.
+
+## Install
+
+```bash
+cd Client-PC/GUI
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Run in proxy mode
+
+Start the Pi server first, then start the dashboard in front of it.
+
+```bash
+cd Server-Pi/Network-Stack
+go run . -public -port 8080
+```
+
+```bash
+cd Client-PC/GUI
+python dashboard.py --listen-port 8090 --forward-to 127.0.0.1:8080
+```
+
+Then point the repo clients at the dashboard listener instead of the server:
+
+```bash
+cd Client-PC/Network-Stack
+go run . -server 127.0.0.1:8090
+```
+
+```bash
+cd Client-Jetson/Network-Stack
+go run . -server 127.0.0.1:8090
+```
+
+Open the web UI at:
+
+```bash
+http://127.0.0.1:8050
+```
+
+## Run as a desktop app
+
+If you do not want to use a browser tab, launch the dashboard in desktop mode:
+
+```bash
+cd Client-PC/GUI
+python dashboard.py --desktop --listen-port 8090 --ui-port 8050 --forward-to 127.0.0.1:8080
+```
+
+This opens the Dash UI inside a native window using `pywebview`.
+
+## Run in monitor-only mode
+
+```bash
+cd Client-PC/GUI
+python dashboard.py --listen-port 8090
+```
+
+This is useful if you want to test packet parsing without forwarding to a live
+server.
+
+## Useful flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--listen-host` | `0.0.0.0` | TCP host for incoming Go client packets |
+| `--listen-port` | `8090` | TCP port for incoming Go client packets |
+| `--ui-host` | `127.0.0.1` | Host for the Dash UI |
+| `--ui-port` | `8050` | Port for the Dash UI |
+| `--forward-to` | empty | Optional real server target in `host:port` form |
+| `--max-packet-size` | `8192` | Protocol guard for payload size |
+
+## What the UI shows
+
+- Controller stick, trigger, button, and d-pad state from `Client-PC`
+- Sequence number, packet size, CRC result, peer address, and forward status
+- Live Jetson status packets from `Client-Jetson`
+- Raw packet previews and connection logs for debugging

--- a/Client-PC/GUI/dashboard.py
+++ b/Client-PC/GUI/dashboard.py
@@ -1,0 +1,1008 @@
+import argparse
+import json
+import os
+import socket
+import struct
+import threading
+import time
+import zlib
+from collections import deque
+
+import dash
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+from dash.dependencies import Input, Output
+
+
+DEFAULT_CONTROLLER_STATE = {
+    "N": 0,
+    "E": 0,
+    "S": 0,
+    "W": 0,
+    "LB": 0,
+    "RB": 0,
+    "LS": 0,
+    "RS": 0,
+    "SELECT": 0,
+    "START": 0,
+    "LjoyX": 127,
+    "LjoyY": 127,
+    "RjoyX": 127,
+    "RjoyY": 127,
+    "LT": 0,
+    "RT": 0,
+    "dX": 0,
+    "dY": 0,
+    "ts": 0,
+    "seq": 0,
+    "source": "pc",
+}
+
+ROVER_STATE_FILE = "/tmp/rover_state"
+ROVER_STATE_REQUEST_FILE = "/tmp/rover_state_request"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="FIU Luna1 teleop dashboard. Monitors packets and can proxy them to the server."
+    )
+    parser.add_argument("--listen-host", default="0.0.0.0", help="TCP host for the dashboard packet listener")
+    parser.add_argument("--listen-port", type=int, default=8090, help="TCP port for incoming packets from Go clients")
+    parser.add_argument("--ui-host", default="127.0.0.1", help="Host for the Dash web UI")
+    parser.add_argument("--ui-port", type=int, default=8050, help="Port for the Dash web UI")
+    parser.add_argument(
+        "--ui-refresh-ms",
+        type=int,
+        default=40,
+        help="Dashboard polling interval in milliseconds",
+    )
+    parser.add_argument("--desktop", action="store_true", help="Open the UI in a native desktop window")
+    parser.add_argument("--window-width", type=int, default=1400, help="Desktop window width")
+    parser.add_argument("--window-height", type=int, default=920, help="Desktop window height")
+    parser.add_argument(
+        "--forward-to",
+        default="",
+        help="Optional upstream host:port. When set, packets are forwarded unchanged to the real server.",
+    )
+    parser.add_argument(
+        "--max-packet-size",
+        type=int,
+        default=8192,
+        help="Maximum JSON payload size before CRC bytes are appended",
+    )
+    return parser.parse_args()
+
+
+CONFIG = parse_args()
+
+
+state_lock = threading.Lock()
+latest_controller_state = dict(DEFAULT_CONTROLLER_STATE)
+latest_controller_meta = {
+    "crc_ok": False,
+    "bytes": 0,
+    "peer": "",
+    "source": "pc",
+    "seq": 0,
+    "last_rx": 0.0,
+    "forwarded": False,
+    "packet_type": "none",
+}
+status_sources = {}
+status_history = deque(maxlen=40)
+log_lines = deque(maxlen=300)
+raw_packets = deque(maxlen=60)
+metrics = {
+    "connections_current": 0,
+    "connections_total": 0,
+    "packets_rx": 0,
+    "packets_forwarded": 0,
+    "forward_failures": 0,
+    "controller_packets": 0,
+    "status_packets": 0,
+    "crc_failures": 0,
+    "json_failures": 0,
+}
+
+
+def log(message: str):
+    timestamp = time.strftime("%H:%M:%S")
+    line = f"[{timestamp}] {message}"
+    with state_lock:
+        log_lines.append(line)
+
+
+def parse_target(target: str):
+    if not target:
+        return None
+    if ":" not in target:
+        raise ValueError(f"forward target must be host:port, got {target!r}")
+    host, port = target.rsplit(":", 1)
+    return host, int(port)
+
+
+FORWARD_TARGET = parse_target(CONFIG.forward_to) if CONFIG.forward_to else None
+
+
+def read_exact(sock: socket.socket, size: int):
+    data = bytearray()
+    while len(data) < size:
+        chunk = sock.recv(size - len(data))
+        if not chunk:
+            return None
+        data.extend(chunk)
+    return bytes(data)
+
+
+def open_upstream_connection():
+    if not FORWARD_TARGET:
+        return None
+    upstream = socket.create_connection(FORWARD_TARGET, timeout=3.0)
+    upstream.settimeout(5.0)
+    return upstream
+
+
+def verify_packet(packet: bytes):
+    if len(packet) < 4:
+        return None, False
+    payload = packet[:-4]
+    expected = struct.unpack(">I", packet[-4:])[0]
+    actual = zlib.crc32(payload) & 0xFFFFFFFF
+    return payload, actual == expected
+
+
+def infer_mode(state):
+    active = (
+        state.get("N", 0)
+        or state.get("E", 0)
+        or state.get("S", 0)
+        or state.get("W", 0)
+        or state.get("LB", 0)
+        or state.get("RB", 0)
+        or state.get("LS", 0)
+        or state.get("RS", 0)
+        or state.get("SELECT", 0)
+        or state.get("START", 0)
+        or abs(int(state.get("dX", 0)))
+        or abs(int(state.get("dY", 0)))
+        or abs(int(state.get("LjoyX", 127)) - 127) > 3
+        or abs(int(state.get("LjoyY", 127)) - 127) > 3
+        or abs(int(state.get("RjoyX", 127)) - 127) > 3
+        or abs(int(state.get("RjoyY", 127)) - 127) > 3
+        or int(state.get("LT", 0)) > 3
+        or int(state.get("RT", 0)) > 3
+    )
+    return "TELEOP" if active else "IDLE"
+
+
+def infer_state_combo(state):
+    if int(state.get("SELECT", 0)) == 0:
+        return "idle", "", "Hold SELECT to enter state change mode."
+    if int(state.get("N", 0)) == 1:
+        return "request", "TELEOP", "SELECT + Y/N -> TELEOP"
+    if int(state.get("E", 0)) == 1:
+        return "request", "AUTO", "SELECT + B/E -> AUTO"
+    if int(state.get("W", 0)) == 1:
+        return "request", "IDLE", "SELECT + X/W -> IDLE"
+    return "armed", "", "SELECT held. Press Y, B, or X to request a mode."
+
+
+def read_rover_state_file(path):
+    try:
+        raw = open(path, "r", encoding="utf-8").read().strip()
+    except OSError:
+        return None
+
+    if not raw:
+        return None
+
+    parts = [part.strip() for part in raw.split(",")]
+    if len(parts) < 2:
+        return {"raw": raw, "valid": False}
+
+    try:
+        timestamp = int(parts[1])
+    except ValueError:
+        return {"raw": raw, "valid": False}
+
+    return {
+        "raw": raw,
+        "valid": True,
+        "state": parts[0],
+        "timestamp": timestamp,
+        "source": parts[2] if len(parts) > 2 else "",
+        "seq": parts[3] if len(parts) > 3 else "",
+    }
+
+
+def state_age_text(timestamp_ms):
+    if not timestamp_ms:
+        return "unknown"
+    return age_text(max(0.0, time.time() - (timestamp_ms / 1000.0)))
+
+
+def record_raw_packet(peer, total_len, packet_type, source, crc_ok, forwarded, packet):
+    raw_packets.appendleft(
+        {
+            "t": time.strftime("%H:%M:%S"),
+            "peer": peer,
+            "bytes": total_len,
+            "packet_type": packet_type,
+            "source": source,
+            "crc_ok": crc_ok,
+            "forwarded": forwarded,
+            "raw_hex": packet.hex()[:480] + ("..." if len(packet) > 240 else ""),
+        }
+    )
+
+
+def update_state_from_packet(peer, total_len, packet, forwarded):
+    payload, crc_ok = verify_packet(packet)
+    packet_type = "unknown"
+    source = peer
+    now = time.time()
+    log_message = None
+
+    with state_lock:
+        metrics["packets_rx"] += 1
+
+        if not crc_ok or payload is None:
+            metrics["crc_failures"] += 1
+            latest_controller_meta.update(
+                {
+                    "crc_ok": False,
+                    "bytes": total_len,
+                    "peer": peer,
+                    "last_rx": now,
+                    "forwarded": forwarded,
+                    "packet_type": "crc_fail",
+                }
+            )
+            record_raw_packet(peer, total_len, "crc_fail", source, False, forwarded, packet)
+            log_message = f"CRC mismatch from {peer}"
+        else:
+            try:
+                obj = json.loads(payload.decode("utf-8"))
+            except Exception as exc:
+                metrics["json_failures"] += 1
+                latest_controller_meta.update(
+                    {
+                        "crc_ok": True,
+                        "bytes": total_len,
+                        "peer": peer,
+                        "last_rx": now,
+                        "forwarded": forwarded,
+                        "packet_type": "json_error",
+                    }
+                )
+                record_raw_packet(peer, total_len, "json_error", source, True, forwarded, packet)
+                log_message = f"JSON parse failed from {peer}: {exc}"
+            else:
+                if not isinstance(obj, dict):
+                    metrics["json_failures"] += 1
+                    latest_controller_meta.update(
+                        {
+                            "crc_ok": True,
+                            "bytes": total_len,
+                            "peer": peer,
+                            "last_rx": now,
+                            "forwarded": forwarded,
+                            "packet_type": "json_error",
+                        }
+                    )
+                    record_raw_packet(peer, total_len, "json_error", source, True, forwarded, packet)
+                    log_message = f"Unexpected JSON payload type from {peer}"
+                elif obj.get("type") == "status":
+                    packet_type = "status"
+                    source = obj.get("source") or peer
+                    metrics["status_packets"] += 1
+                    status_sources[source] = {
+                        "message": obj.get("message", ""),
+                        "ts": obj.get("ts", 0),
+                        "peer": peer,
+                        "last_rx": now,
+                    }
+                    status_history.appendleft(
+                        {
+                            "source": source,
+                            "message": obj.get("message", ""),
+                            "peer": peer,
+                            "ts": obj.get("ts", 0),
+                            "received": now,
+                        }
+                    )
+                    latest_controller_meta.update(
+                        {
+                            "crc_ok": True,
+                            "bytes": total_len,
+                            "peer": peer,
+                            "last_rx": now,
+                            "forwarded": forwarded,
+                            "packet_type": packet_type,
+                        }
+                    )
+                    log_message = f"Status packet from {source}: {obj.get('message', '')}"
+                    record_raw_packet(peer, total_len, packet_type, source, True, forwarded, packet)
+                else:
+                    packet_type = "controller"
+                    source = obj.get("source") or peer
+                    metrics["controller_packets"] += 1
+                    for key in DEFAULT_CONTROLLER_STATE:
+                        if key in obj:
+                            latest_controller_state[key] = obj[key]
+                    latest_controller_state["source"] = source
+                    latest_controller_meta.update(
+                        {
+                            "crc_ok": True,
+                            "bytes": total_len,
+                            "peer": peer,
+                            "source": source,
+                            "seq": obj.get("seq", 0),
+                            "last_rx": now,
+                            "forwarded": forwarded,
+                            "packet_type": packet_type,
+                        }
+                    )
+                    record_raw_packet(peer, total_len, packet_type, source, True, forwarded, packet)
+
+    if log_message:
+        log(log_message)
+
+
+def connection_thread(conn: socket.socket, addr):
+    peer = f"{addr[0]}:{addr[1]}"
+    upstream = None
+
+    with state_lock:
+        metrics["connections_current"] += 1
+        metrics["connections_total"] += 1
+
+    try:
+        if FORWARD_TARGET:
+            try:
+                upstream = open_upstream_connection()
+                log(f"{peer} connected, forwarding to {FORWARD_TARGET[0]}:{FORWARD_TARGET[1]}")
+            except OSError as exc:
+                with state_lock:
+                    metrics["forward_failures"] += 1
+                log(f"Upstream unavailable for {peer}: {exc}")
+                return
+        else:
+            log(f"{peer} connected in monitor-only mode")
+
+        conn.settimeout(5.0)
+        while True:
+            hdr = read_exact(conn, 4)
+            if not hdr:
+                break
+
+            total_len = struct.unpack(">I", hdr)[0]
+            if total_len == 0:
+                log(f"Zero-length packet from {peer}")
+                continue
+            if total_len > (CONFIG.max_packet_size + 4):
+                log(f"Oversized packet {total_len}B from {peer}; closing connection")
+                break
+
+            packet = read_exact(conn, total_len)
+            if not packet:
+                break
+
+            forwarded = False
+            if upstream is not None:
+                try:
+                    upstream.sendall(hdr)
+                    upstream.sendall(packet)
+                    forwarded = True
+                    with state_lock:
+                        metrics["packets_forwarded"] += 1
+                except OSError as exc:
+                    with state_lock:
+                        metrics["forward_failures"] += 1
+                    log(f"Forwarding failed for {peer}: {exc}")
+                    break
+
+            update_state_from_packet(peer, total_len, packet, forwarded)
+    except socket.timeout:
+        log(f"Connection timeout from {peer}")
+    except OSError as exc:
+        log(f"Socket error from {peer}: {exc}")
+    finally:
+        if upstream is not None:
+            upstream.close()
+        conn.close()
+        with state_lock:
+            metrics["connections_current"] = max(0, metrics["connections_current"] - 1)
+        log(f"{peer} disconnected")
+
+
+def proxy_server_thread():
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind((CONFIG.listen_host, CONFIG.listen_port))
+    server.listen(8)
+
+    if FORWARD_TARGET:
+        log(
+            f"Packet listener on {CONFIG.listen_host}:{CONFIG.listen_port}, proxying to "
+            f"{FORWARD_TARGET[0]}:{FORWARD_TARGET[1]}"
+        )
+    else:
+        log(f"Packet listener on {CONFIG.listen_host}:{CONFIG.listen_port} (monitor only)")
+
+    while True:
+        conn, addr = server.accept()
+        thread = threading.Thread(target=connection_thread, args=(conn, addr), daemon=True)
+        thread.start()
+
+
+def joystick_widget(title, x, y, size=170):
+    px = max(0, min(100, (x / 255) * 100))
+    py = max(0, min(100, (y / 255) * 100))
+
+    box_style = {
+        "position": "relative",
+        "width": f"{size}px",
+        "height": f"{size}px",
+        "border": "1px solid #556",
+        "borderRadius": "12px",
+        "background": "#0f1724",
+        "margin": "6px auto",
+    }
+    dot_style = {
+        "position": "absolute",
+        "left": f"calc({px}% - 7px)",
+        "top": f"calc({py}% - 7px)",
+        "width": "14px",
+        "height": "14px",
+        "borderRadius": "50%",
+        "background": "#18d2a6",
+        "boxShadow": "0 0 12px rgba(24,210,166,0.6)",
+    }
+    cross_vertical = {
+        "position": "absolute",
+        "left": "50%",
+        "top": "0",
+        "width": "1px",
+        "height": "100%",
+        "background": "#263247",
+    }
+    cross_horizontal = {
+        "position": "absolute",
+        "left": "0",
+        "top": "50%",
+        "width": "100%",
+        "height": "1px",
+        "background": "#263247",
+    }
+
+    return dbc.Card(
+        dbc.CardBody(
+            [
+                html.Div(title, style={"textAlign": "center", "fontWeight": "bold"}),
+                html.Div(
+                    [
+                        html.Div(style=cross_vertical),
+                        html.Div(style=cross_horizontal),
+                        html.Div(style=dot_style),
+                    ],
+                    style=box_style,
+                ),
+                html.Div(f"X={x}  Y={y}", style={"textAlign": "center", "fontFamily": "monospace"}),
+            ]
+        ),
+        className="mb-3",
+    )
+
+
+def trigger_bar(title, value):
+    return dbc.Card(
+        dbc.CardBody(
+            [
+                html.Div(title, style={"fontWeight": "bold"}),
+                dbc.Progress(
+                    value=int(value),
+                    max=255,
+                    color="info",
+                    animated=False,
+                    striped=False,
+                    style={"height": "18px", "transition": "none"},
+                ),
+                html.Div(f"{value}/255", style={"fontFamily": "monospace", "marginTop": "6px"}),
+            ]
+        ),
+        className="mb-3",
+    )
+
+
+def button_light(label, enabled):
+    return html.Div(
+        [
+            html.Div(
+                style={
+                    "width": "14px",
+                    "height": "14px",
+                    "borderRadius": "50%",
+                    "background": "#3ff58f" if enabled else "#2c3548",
+                    "display": "inline-block",
+                    "marginRight": "8px",
+                    "boxShadow": "0 0 10px rgba(63,245,143,0.5)" if enabled else "none",
+                }
+            ),
+            html.Span(label, style={"fontFamily": "monospace"}),
+        ],
+        style={"marginBottom": "6px"},
+    )
+
+
+def age_text(seconds):
+    if seconds is None:
+        return "never"
+    return f"{seconds:.2f}s ago"
+
+
+app = dash.Dash(__name__, external_stylesheets=[dbc.themes.CYBORG])
+app.title = "FIU Luna1 Teleop Dashboard"
+
+app.layout = dbc.Container(
+    fluid=True,
+    children=[
+        html.H2("FIU Luna1 Teleop Dashboard"),
+        html.Div(
+            "Monitor the repo's wire protocol live and optionally proxy packets to Server-Pi.",
+            className="mb-3 text-muted",
+        ),
+        html.Div(id="status-bar", style={"fontFamily": "monospace", "marginBottom": "12px"}),
+        dcc.Interval(id="tick", interval=max(16, CONFIG.ui_refresh_ms), n_intervals=0),
+        dbc.Row(
+            [
+                dbc.Col(
+                    dbc.Card(
+                        dbc.CardBody(
+                            [
+                                html.Div("Input Activity", style={"fontWeight": "bold"}),
+                                html.H4(id="mode-label", style={"marginTop": "10px"}),
+                                html.Div(id="controller-summary", style={"fontFamily": "monospace"}),
+                            ]
+                        )
+                    ),
+                    md=4,
+                ),
+                dbc.Col(
+                    dbc.Card(
+                        dbc.CardBody(
+                            [
+                                html.Div("Network", style={"fontWeight": "bold"}),
+                                html.Div(id="network-summary", style={"fontFamily": "monospace", "marginTop": "10px"}),
+                            ]
+                        )
+                    ),
+                    md=4,
+                ),
+                dbc.Col(
+                    dbc.Card(
+                        dbc.CardBody(
+                            [
+                                html.Div("Traffic", style={"fontWeight": "bold"}),
+                                html.Div(id="traffic-summary", style={"fontFamily": "monospace", "marginTop": "10px"}),
+                            ]
+                        )
+                    ),
+                    md=4,
+                ),
+            ],
+            className="mb-3",
+        ),
+        dbc.Tabs(
+            [
+                dbc.Tab(label="Controller", tab_id="controller"),
+                dbc.Tab(label="Jetson Status", tab_id="status"),
+                dbc.Tab(label="Logs / Raw", tab_id="logs"),
+            ],
+            id="tabs",
+            active_tab="controller",
+            className="mb-3",
+        ),
+        html.Div(id="tab-content"),
+    ],
+)
+
+
+@app.callback(
+    Output("status-bar", "children"),
+    Output("mode-label", "children"),
+    Output("controller-summary", "children"),
+    Output("network-summary", "children"),
+    Output("traffic-summary", "children"),
+    Output("tab-content", "children"),
+    Input("tick", "n_intervals"),
+    Input("tabs", "active_tab"),
+)
+def update_ui(_, active_tab):
+    with state_lock:
+        controller = dict(latest_controller_state)
+        meta = dict(latest_controller_meta)
+        traffic = dict(metrics)
+        status_source_count = len(status_sources)
+
+        statuses = {}
+        status_log = []
+        logs_snapshot = []
+        raw_snapshot = []
+
+        if active_tab == "status":
+            statuses = dict(status_sources)
+            status_log = list(status_history)
+        elif active_tab == "logs":
+            logs_snapshot = list(log_lines)
+            raw_snapshot = list(raw_packets)
+
+    last_rx_age = (time.time() - meta["last_rx"]) if meta["last_rx"] else None
+    mode = infer_mode(controller)
+    forward_label = CONFIG.forward_to if CONFIG.forward_to else "disabled"
+    combo_state, requested_mode, combo_text = infer_state_combo(controller)
+    rover_state = read_rover_state_file(ROVER_STATE_FILE)
+    rover_request = read_rover_state_file(ROVER_STATE_REQUEST_FILE)
+
+    status_bar = (
+        f"listener={CONFIG.listen_host}:{CONFIG.listen_port} | "
+        f"ui=http://{CONFIG.ui_host}:{CONFIG.ui_port} | "
+        f"forward={forward_label} | "
+        f"last_packet={meta['packet_type']} | "
+        f"last_rx={age_text(last_rx_age)}"
+    )
+
+    controller_summary = [
+        html.Div(f"source: {meta.get('source') or controller.get('source') or 'pc'}"),
+        html.Div(f"seq: {meta.get('seq', 0)}"),
+        html.Div(f"peer: {meta.get('peer', '-') or '-'}"),
+        html.Div(f"bytes: {meta.get('bytes', 0)}"),
+        html.Div(f"crc_ok: {meta.get('crc_ok', False)}"),
+        html.Div(f"forwarded: {meta.get('forwarded', False)}"),
+        html.Div(f"state combo: {combo_text}"),
+    ]
+
+    network_summary = [
+        html.Div(f"listen: {CONFIG.listen_host}:{CONFIG.listen_port}"),
+        html.Div(f"forward: {forward_label}"),
+        html.Div(f"active clients: {traffic['connections_current']}"),
+        html.Div(f"client sessions: {traffic['connections_total']}"),
+        html.Div(f"ui refresh: {max(16, CONFIG.ui_refresh_ms)}ms"),
+        html.Div(f"jetson sources: {status_source_count}"),
+    ]
+
+    traffic_summary = [
+        html.Div(f"rx packets: {traffic['packets_rx']}"),
+        html.Div(f"forwarded: {traffic['packets_forwarded']}"),
+        html.Div(f"controller packets: {traffic['controller_packets']}"),
+        html.Div(f"status packets: {traffic['status_packets']}"),
+        html.Div(f"crc failures: {traffic['crc_failures']}"),
+        html.Div(f"forward failures: {traffic['forward_failures']}"),
+    ]
+
+    if active_tab == "controller":
+        content = dbc.Row(
+            [
+                dbc.Col(
+                    [
+                        joystick_widget("Left Stick", int(controller["LjoyX"]), int(controller["LjoyY"])),
+                        trigger_bar("Left Trigger", int(controller["LT"])),
+                    ],
+                    md=4,
+                ),
+                dbc.Col(
+                    [
+                        joystick_widget("Right Stick", int(controller["RjoyX"]), int(controller["RjoyY"])),
+                        trigger_bar("Right Trigger", int(controller["RT"])),
+                    ],
+                    md=4,
+                ),
+                dbc.Col(
+                    dbc.Card(
+                        dbc.CardBody(
+                            [
+                                html.Div("Buttons", style={"fontWeight": "bold", "marginBottom": "10px"}),
+                                button_light("N", controller["N"] == 1),
+                                button_light("E", controller["E"] == 1),
+                                button_light("S", controller["S"] == 1),
+                                button_light("W", controller["W"] == 1),
+                                html.Hr(),
+                                button_light("LB", controller["LB"] == 1),
+                                button_light("RB", controller["RB"] == 1),
+                                button_light("LS", controller["LS"] == 1),
+                                button_light("RS", controller["RS"] == 1),
+                                html.Hr(),
+                                button_light("SELECT", controller["SELECT"] == 1),
+                                button_light("START", controller["START"] == 1),
+                                html.Hr(),
+                                html.Div(
+                                    f"DPad: x={controller['dX']} y={controller['dY']}",
+                                    style={"fontFamily": "monospace"},
+                                ),
+                                html.Div(
+                                    f"Source: {controller.get('source', 'pc')}",
+                                    style={"fontFamily": "monospace", "marginTop": "8px"},
+                                ),
+                                html.Div(
+                                    f"Timestamp: {controller.get('ts', 0)}",
+                                    style={"fontFamily": "monospace"},
+                                ),
+                                html.Hr(),
+                                html.Div("State Switch", style={"fontWeight": "bold", "marginBottom": "10px"}),
+                                html.Div(
+                                    f"Combo status: {combo_state}",
+                                    style={"fontFamily": "monospace"},
+                                ),
+                                html.Div(
+                                    f"Requested mode: {requested_mode or 'none'}",
+                                    style={"fontFamily": "monospace"},
+                                ),
+                                html.Div(
+                                    combo_text,
+                                    style={"fontFamily": "monospace"},
+                                ),
+                                html.Div(
+                                    f"Pending request: "
+                                    f"{rover_request.get('state', 'none') if rover_request else 'none'}",
+                                    style={"fontFamily": "monospace", "marginTop": "8px"},
+                                ),
+                                html.Div(
+                                    (
+                                        f"Pending seq/source: "
+                                        f"{rover_request.get('seq', '-')}/{rover_request.get('source', '-')}"
+                                        if rover_request and rover_request.get("valid")
+                                        else "Pending seq/source: -"
+                                    ),
+                                    style={"fontFamily": "monospace"},
+                                ),
+                                html.Div(
+                                    f"Rover state: {rover_state.get('state', 'unknown') if rover_state else 'unknown'}",
+                                    style={"fontFamily": "monospace", "marginTop": "8px"},
+                                ),
+                                html.Div(
+                                    (
+                                        f"Rover state age: {state_age_text(rover_state.get('timestamp'))}"
+                                        if rover_state and rover_state.get("valid")
+                                        else "Rover state age: unknown"
+                                    ),
+                                    style={"fontFamily": "monospace"},
+                                ),
+                            ]
+                        )
+                    ),
+                    md=4,
+                ),
+            ]
+        )
+    elif active_tab == "status":
+        if statuses:
+            rows = []
+            for source, entry in sorted(statuses.items(), key=lambda item: item[1]["last_rx"], reverse=True):
+                age = time.time() - entry["last_rx"]
+                rows.append(
+                    html.Tr(
+                        [
+                            html.Td(source),
+                            html.Td(entry["message"]),
+                            html.Td(entry["peer"]),
+                            html.Td(age_text(age)),
+                            html.Td(entry["ts"]),
+                        ]
+                    )
+                )
+        else:
+            rows = [html.Tr([html.Td("No status packets received yet", colSpan=5)])]
+
+        recent = []
+        for entry in status_log[:12]:
+            recent.append(
+                html.Div(
+                    f"{entry['source']} | {entry['message']} | peer={entry['peer']} | ts={entry['ts']}",
+                    style={"fontFamily": "monospace", "fontSize": "12px", "marginBottom": "6px"},
+                )
+            )
+
+        content = dbc.Row(
+            [
+                dbc.Col(
+                    dbc.Card(
+                        dbc.CardBody(
+                            [
+                                html.Div("Latest status by source", style={"fontWeight": "bold", "marginBottom": "10px"}),
+                                dbc.Table(
+                                    [
+                                        html.Thead(
+                                            html.Tr(
+                                                [
+                                                    html.Th("Source"),
+                                                    html.Th("Message"),
+                                                    html.Th("Peer"),
+                                                    html.Th("Age"),
+                                                    html.Th("ts"),
+                                                ]
+                                            )
+                                        ),
+                                        html.Tbody(rows),
+                                    ],
+                                    bordered=True,
+                                    hover=True,
+                                    responsive=True,
+                                    size="sm",
+                                ),
+                            ]
+                        )
+                    ),
+                    md=7,
+                ),
+                dbc.Col(
+                    dbc.Card(
+                        dbc.CardBody(
+                            [
+                                html.Div("Recent status traffic", style={"fontWeight": "bold", "marginBottom": "10px"}),
+                                html.Div(
+                                    recent or [html.Div("No status traffic yet.", style={"fontFamily": "monospace"})],
+                                    style={"maxHeight": "420px", "overflowY": "auto"},
+                                ),
+                            ]
+                        )
+                    ),
+                    md=5,
+                ),
+            ]
+        )
+    else:
+        log_text = "\n".join(logs_snapshot[-200:])
+        raw_text = "\n".join(
+            [
+                (
+                    f"{pkt['t']}  {pkt['packet_type']}  src={pkt['source']}  peer={pkt['peer']}  "
+                    f"{pkt['bytes']}B  crc_ok={pkt['crc_ok']}  forwarded={pkt['forwarded']}  hex={pkt['raw_hex']}"
+                )
+                for pkt in raw_snapshot[:25]
+            ]
+        )
+
+        content = dbc.Row(
+            [
+                dbc.Col(
+                    dbc.Card(
+                        dbc.CardBody(
+                            [
+                                html.Div("Logs", style={"fontWeight": "bold", "marginBottom": "10px"}),
+                                html.Pre(
+                                    log_text or "No logs yet.",
+                                    style={
+                                        "background": "#0b1119",
+                                        "border": "1px solid #263247",
+                                        "padding": "12px",
+                                        "height": "420px",
+                                        "overflowY": "auto",
+                                        "fontFamily": "Consolas, monospace",
+                                        "fontSize": "12px",
+                                        "color": "#d9e2f2",
+                                    },
+                                ),
+                            ]
+                        )
+                    ),
+                    md=6,
+                ),
+                dbc.Col(
+                    dbc.Card(
+                        dbc.CardBody(
+                            [
+                                html.Div("Raw packet preview", style={"fontWeight": "bold", "marginBottom": "10px"}),
+                                html.Pre(
+                                    raw_text or "No packets received yet.",
+                                    style={
+                                        "background": "#0b1119",
+                                        "border": "1px solid #263247",
+                                        "padding": "12px",
+                                        "height": "420px",
+                                        "overflowY": "auto",
+                                        "fontFamily": "Consolas, monospace",
+                                        "fontSize": "12px",
+                                        "color": "#d9e2f2",
+                                        "whiteSpace": "pre-wrap",
+                                    },
+                                ),
+                            ]
+                        )
+                    ),
+                    md=6,
+                ),
+            ]
+        )
+
+    return status_bar, mode, controller_summary, network_summary, traffic_summary, content
+
+
+threading.Thread(target=proxy_server_thread, daemon=True).start()
+
+
+def run_browser_mode():
+    print(
+        "Starting dashboard UI on "
+        f"http://{CONFIG.ui_host}:{CONFIG.ui_port} | "
+        f"packet listener on {CONFIG.listen_host}:{CONFIG.listen_port}"
+    )
+    app.run(host=CONFIG.ui_host, port=CONFIG.ui_port, debug=False)
+
+
+def run_desktop_mode():
+    if os.environ.get("SNAP_NAME") == "code":
+        # VS Code's snap injects GTK/GIO paths that break pywebview's desktop backend.
+        for key in list(os.environ):
+            if key.startswith("SNAP"):
+                os.environ.pop(key, None)
+
+        for key in [
+            "GDK_PIXBUF_MODULEDIR",
+            "GDK_PIXBUF_MODULE_FILE",
+            "GIO_LAUNCHED_DESKTOP_FILE",
+            "GIO_LAUNCHED_DESKTOP_FILE_PID",
+            "GIO_MODULE_DIR",
+            "GSETTINGS_SCHEMA_DIR",
+            "GTK_EXE_PREFIX",
+            "GTK_IM_MODULE_FILE",
+            "GTK_MODULES",
+            "GTK_PATH",
+            "LOCPATH",
+            "VSCODE_NLS_CONFIG",
+        ]:
+            os.environ.pop(key, None)
+
+        if "XDG_DATA_DIRS_VSCODE_SNAP_ORIG" in os.environ:
+            os.environ["XDG_DATA_DIRS"] = os.environ["XDG_DATA_DIRS_VSCODE_SNAP_ORIG"]
+        if "XDG_CONFIG_DIRS_VSCODE_SNAP_ORIG" in os.environ:
+            os.environ["XDG_CONFIG_DIRS"] = os.environ["XDG_CONFIG_DIRS_VSCODE_SNAP_ORIG"]
+
+    try:
+        import webview
+    except ImportError as exc:
+        raise SystemExit(
+            "Desktop mode requires pywebview. Install it with:\n"
+            "  pip install pywebview\n"
+            "or install from requirements.txt again."
+        ) from exc
+
+    ui_url = f"http://{CONFIG.ui_host}:{CONFIG.ui_port}"
+
+    def run_dash_server():
+        app.run(
+            host=CONFIG.ui_host,
+            port=CONFIG.ui_port,
+            debug=False,
+            use_reloader=False,
+        )
+
+    threading.Thread(target=run_dash_server, daemon=True).start()
+
+    deadline = time.time() + 10.0
+    while time.time() < deadline:
+        try:
+            probe = socket.create_connection((CONFIG.ui_host, CONFIG.ui_port), timeout=0.5)
+            probe.close()
+            break
+        except OSError:
+            time.sleep(0.1)
+
+    print(
+        "Starting desktop dashboard window | "
+        f"embedded UI={ui_url} | "
+        f"packet listener={CONFIG.listen_host}:{CONFIG.listen_port}"
+    )
+    window = webview.create_window(
+        "FIU Luna1 Teleop Dashboard",
+        ui_url,
+        width=CONFIG.window_width,
+        height=CONFIG.window_height,
+    )
+    webview.start()
+
+
+if __name__ == "__main__":
+    if CONFIG.desktop:
+        run_desktop_mode()
+    else:
+        run_browser_mode()

--- a/Client-PC/GUI/requirements.txt
+++ b/Client-PC/GUI/requirements.txt
@@ -1,0 +1,3 @@
+dash>=2.18,<3
+dash-bootstrap-components>=1.6,<2
+pywebview>=5,<6

--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ Max packet size is 8192 bytes. CRC32 (IEEE) is computed over the JSON payload on
 - Configurable byte formatter converts `ControllerState` → Arduino byte array via JSON config
 - Serial output to Arduino at 9600 baud (`/dev/ttyACM0`), with optional CRC and ACK support
 
-**Byte Formatting** — Two config templates:
-- 6-byte (default): start marker + analog fields + button bits + end marker
-- 8-byte extended: full button bitfield + all analog axes + frame markers (0xFF)
+**Byte Formatting** — Current default config template:
+- 8-byte controller format: frame markers + primary buttons + secondary control bits + full analog stick axes
 
 ---
 
@@ -123,6 +122,63 @@ Replace `<PI_IP>` with the Raspberry Pi's IP address on your network.
 
 The client will scan for a gamepad on startup, connect to the server, and begin streaming controller state at ~33 Hz. If the connection drops, it retries every 3 seconds automatically.
 
+## GUI Dashboard
+
+The `motorControl` branch now includes a repo-owned GUI at `Client-PC/GUI`.
+It speaks the same framed JSON + CRC32 protocol as the Go services and can sit
+between the clients and the Pi server as a transparent monitor/proxy.
+
+Local one-machine test:
+
+```bash
+cd Client-PC/GUI
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python dashboard.py --listen-port 8090 --forward-to 127.0.0.1:8080
+```
+
+Then point the Go clients to the dashboard listener:
+
+```bash
+cd Client-PC/Network-Stack
+go run . -server 127.0.0.1:8090
+```
+
+```bash
+cd Client-Jetson/Network-Stack
+go run . -server 127.0.0.1:8090
+```
+
+Open the UI at `http://127.0.0.1:8050`.
+
+Remote Pi setup:
+
+Run the Go server on the Raspberry Pi:
+
+```bash
+cd Server-Pi/Network-Stack
+go run . -public -port 8080
+```
+
+Run the GUI on the operator PC and forward traffic to the Pi:
+
+```bash
+cd Client-PC/GUI
+python dashboard.py --listen-port 8090 --ui-port 8050 --forward-to <PI_IP>:8080
+```
+
+Run the PC gamepad client on the same operator PC:
+
+```bash
+cd Client-PC/Network-Stack
+go run . -server 127.0.0.1:8090
+```
+
+In this setup the client talks to the local GUI on `8090`, and the GUI forwards
+validated packets to the Raspberry Pi server on `<PI_IP>:8080`. Replace
+`<PI_IP>` with the Raspberry Pi's actual address on your network.
+
 ---
 
 ## Setting Up Server-Pi
@@ -138,7 +194,7 @@ go build -o server server.go
 |------|---------|-------------|
 | `-port` | `8080` | TCP listen port |
 | `-public` | `false` | Bind to 0.0.0.0 (required for remote clients) |
-| `-config` | *(built-in 6-byte)* | Path to byte-mapping JSON config |
+| `-config` | *(built-in 8-byte)* | Path to byte-mapping JSON config |
 | `-serial-device` | `/dev/ttyACM0` | Arduino serial port |
 | `-serial-crc` | `false` | Append CRC32 to serial data |
 | `-serial-ack` | `false` | Expect ACK (0x06) from Arduino |
@@ -158,4 +214,3 @@ go build -o jetsonclient client.go
 | `-source` | `jetson` | Source label in packets |
 | `-message` | `connected` | Status message |
 | `-hz` | `1` | Send rate in Hz |
-

--- a/Server-Pi/Network-Stack/README.md
+++ b/Server-Pi/Network-Stack/README.md
@@ -8,6 +8,14 @@ Jetson client (status heartbeats). Incoming packets are CRC-verified, logged in
 batches for debugging, and the controller state is formatted into bytes and
 forwarded to an Arduino over serial.
 
+The server also detects controller-driven rover mode requests. Holding
+`SELECT` for at least 0.5s and then pressing a mapped face button writes a
+request file for the rover FSM:
+
+- `Y / N` -> `TELEOP`
+- `B / E` -> `AUTO`
+- `X / W` -> `IDLE`
+
 ## Wire format
 
 Same protocol as the clients:
@@ -33,7 +41,7 @@ go build -o server .
 |-------------------|----------------------|--------------------------------------------|
 | `-port`           | `8080`               | TCP listen port                            |
 | `-public`         | `false`              | Bind to 0.0.0.0 instead of localhost       |
-| `-config`         | (built-in 6-byte)    | Path to byte-mapping JSON config           |
+| `-config`         | (built-in 8-byte)    | Path to byte-mapping JSON config           |
 | `-serial-device`  | `/dev/ttyACM0`       | Serial device path for Arduino             |
 | `-serial-crc`     | `false`              | Append CRC32 to serial writes              |
 | `-serial-ack`     | `false`              | Expect 0x06 ACK from Arduino after write   |
@@ -57,10 +65,9 @@ Batches are separated by a blank line.
 ## Byte config templates
 
 The server converts `ControllerState` JSON into a fixed-length byte array for
-the Arduino. Two templates are included:
+the Arduino. The active/default template is:
 
-- `byte_config.json` -- 6-byte format (default)
-- `byte_config_8byte.json` -- 8-byte extended format
+- `byte_config_8byte.json` -- 8-byte controller format (default)
 
 Use `-config <file>` to switch.
 

--- a/Server-Pi/Network-Stack/byte_config_8byte.json
+++ b/Server-Pi/Network-Stack/byte_config_8byte.json
@@ -19,8 +19,15 @@
       ]
     },
     {
-      "type": "field",
-      "field": "LjoyX"
+      "type": "bits",
+      "bits": [
+        {"pos": 0, "field": "LS"},
+        {"pos": 1, "field": "RS"},
+        {"pos": 2, "field": "dX_POS"},
+        {"pos": 3, "field": "dX_NEG"},
+        {"pos": 4, "field": "dY_NEG"},
+        {"pos": 5, "field": "dY_POS"}
+      ]
     },
     {
       "type": "field",
@@ -28,11 +35,11 @@
     },
     {
       "type": "field",
-      "field": "RjoyX"
+      "field": "RjoyY"
     },
     {
       "type": "field",
-      "field": "RjoyY"
+      "field": "LT"
     },
     {
       "type": "field",

--- a/Server-Pi/Network-Stack/server.go
+++ b/Server-Pi/Network-Stack/server.go
@@ -36,9 +36,11 @@ const (
 	BatchSize   = 10
 
 	// The rover state machine publishes its latest mode here for Method 2 gating.
-	roverStateFilePath = "/tmp/rover_state"
+	roverStateFilePath        = "/tmp/rover_state"
+	roverStateRequestFilePath = "/tmp/rover_state_request"
 	// Treat stale state as unsafe so controller packets cannot move the rover.
 	roverStateMaxAge = 2 * time.Second
+	stateChangeHoldDuration = 500 * time.Millisecond
 )
 
 // MaxPacketSize is the upper bound for a single JSON payload in bytes.
@@ -177,6 +179,12 @@ type SerialManager struct {
 	device          string
 }
 
+// StateSwitchTracker debounces SCB-hold state changes from the controller.
+type StateSwitchTracker struct {
+	selectHeldSince time.Time
+	requestIssued   bool
+}
+
 // ============================================================================
 // CRC (IEEE CRC-32)
 // ============================================================================
@@ -210,33 +218,41 @@ func VerifyPacket(payloadWithCRC []byte) (payload []byte, ok bool) {
 // Byte Formatter
 // ============================================================================
 
-// DefaultConfig returns the 6-byte Arduino format.
+// DefaultConfig returns the current 8-byte Arduino format.
 func DefaultConfig() *ByteConfig {
 	return &ByteConfig{
-		OutputSize: 6,
+		OutputSize: 8,
 		Bytes: []ByteMapping{
+			{Type: "const", Value: 0xFF},
 			{
 				Type: "bits",
 				Bits: []BitMapping{
-					{Pos: 0, Field: "W"},
+					{Pos: 0, Field: "N"},
 					{Pos: 1, Field: "E"},
 					{Pos: 2, Field: "S"},
+					{Pos: 3, Field: "W"},
+					{Pos: 4, Field: "LB"},
+					{Pos: 5, Field: "RB"},
+					{Pos: 6, Field: "SELECT"},
+					{Pos: 7, Field: "START"},
 				},
 			},
-			{Type: "field", Field: "LjoyX"},
-			{Type: "field", Field: "LjoyY"},
-			{Type: "field", Field: "RjoyY"},
-			{Type: "field", Field: "RT"},
 			{
 				Type: "bits",
 				Bits: []BitMapping{
-					{Pos: 1, Field: "SELECT"},
-					{Pos: 3, Field: "START"},
-					{Pos: 5, Field: "LB"},
-					{Pos: 6, Field: "RB"},
-					{Pos: 7, Field: "N"},
+					{Pos: 0, Field: "LS"},
+					{Pos: 1, Field: "RS"},
+					{Pos: 2, Field: "dX_POS"},
+					{Pos: 3, Field: "dX_NEG"},
+					{Pos: 4, Field: "dY_NEG"},
+					{Pos: 5, Field: "dY_POS"},
 				},
 			},
+			{Type: "field", Field: "LjoyY"},
+			{Type: "field", Field: "RjoyY"},
+			{Type: "field", Field: "LT"},
+			{Type: "field", Field: "RT"},
+			{Type: "const", Value: 0xFF},
 		},
 	}
 }
@@ -321,6 +337,36 @@ func (f *ByteFormatter) getFieldValue(state *ControllerState, field string) uint
 		return uint8(state.DPadX)
 	case "dY":
 		return uint8(state.DPadY)
+	case "dX_POS":
+		if state.DPadX > 0 {
+			return 1
+		}
+		return 0
+	case "dX_NEG":
+		if state.DPadX < 0 {
+			return 1
+		}
+		return 0
+	case "dY_POS":
+		if state.DPadY > 0 {
+			return 1
+		}
+		return 0
+	case "dY_NEG":
+		if state.DPadY < 0 {
+			return 1
+		}
+		return 0
+	case "LT_ACTIVE":
+		if state.LeftTrigger > 10 {
+			return 1
+		}
+		return 0
+	case "RT_ACTIVE":
+		if state.RightTrigger > 10 {
+			return 1
+		}
+		return 0
 	default:
 		return 0
 	}
@@ -589,6 +635,74 @@ func readRoverState() (string, int64, bool) {
 	return stateName, stateTimestamp, true
 }
 
+func controllerRequestedMode(state *ControllerState) (string, bool) {
+	switch {
+	case state.North != 0:
+		return "TELEOP", true
+	case state.East != 0:
+		return "AUTO", true
+	case state.West != 0:
+		return "IDLE", true
+	default:
+		return "", false
+	}
+}
+
+func writeStateRequest(mode string, timestamp int64, source string, seq uint32) error {
+	tmpPath := roverStateRequestFilePath + ".tmp"
+	f, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintf(f, "%s,%d,%s,%d\n", mode, timestamp, source, seq); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, roverStateRequestFilePath)
+}
+
+func (t *StateSwitchTracker) Handle(state *ControllerState) (string, bool, error) {
+	if state.Select == 0 {
+		t.selectHeldSince = time.Time{}
+		t.requestIssued = false
+		return "", false, nil
+	}
+
+	if t.selectHeldSince.IsZero() {
+		t.selectHeldSince = time.Now()
+		return "", false, nil
+	}
+
+	if t.requestIssued || time.Since(t.selectHeldSince) < stateChangeHoldDuration {
+		return "", false, nil
+	}
+
+	mode, ok := controllerRequestedMode(state)
+	if !ok {
+		return "", false, nil
+	}
+
+	source := state.Source
+	if source == "" {
+		source = "pc"
+	}
+
+	if err := writeStateRequest(mode, time.Now().UnixMilli(), source, state.Seq); err != nil {
+		return "", false, err
+	}
+
+	t.requestIssued = true
+	return mode, true, nil
+}
+
 // Only TELEOP is allowed to forward controller bytes to the Arduino.
 func validRoverState(stateName string) bool {
 	switch stateName {
@@ -625,6 +739,7 @@ func handleClient(conn net.Conn, formatter *ByteFormatter, serialMgr *SerialMana
 	defer batchLog.Close()
 
 	lastPrint := time.Now()
+	switchTracker := &StateSwitchTracker{}
 
 	for {
 		receivedAt := time.Now().UnixMilli()
@@ -702,6 +817,12 @@ func handleClient(conn net.Conn, formatter *ByteFormatter, serialMgr *SerialMana
 		// Log successful packet
 		batchLog.Record(PacketLog{Seq: state.Seq, CRC32: wireCRC, ReceivedAt: receivedAt, Status: StatusOK})
 
+		if mode, changed, err := switchTracker.Handle(&state); err != nil {
+			log.Printf("State request write failed from %s: %v", state.Source, err)
+		} else if changed {
+			log.Printf("[%s] queued rover state request: %s (seq=%d)", state.Source, mode, state.Seq)
+		}
+
 		// Format and send to Arduino
 		data := formatter.Format(&state)
 
@@ -761,7 +882,7 @@ func main() {
 		}
 	} else {
 		formatter.Config = DefaultConfig()
-		log.Println("Using default 6-byte format")
+		log.Println("Using default 8-byte format")
 	}
 
 	// Start TCP listener

--- a/Server-Pi/README.md
+++ b/Server-Pi/README.md
@@ -8,6 +8,8 @@ controller bytes to the Arduino.
 - The serial port can stay open.
 - Every controller packet is still received and parsed by `Network-Stack/server.go`.
 - Before each serial write, the server reads `/tmp/rover_state`.
+- The server can also publish controller-driven state change requests to
+  `/tmp/rover_state_request`.
 - Serial writes are only allowed when the rover state is `TELEOP`.
 - `IDLE`, `AUTO`, missing state data, malformed state data, and stale state data
   all block the serial write.
@@ -34,6 +36,21 @@ TELEOP,1775358012435
 
 Each transition updates `/tmp/rover_state`, which is what the Go server uses
 for Method 2 gating.
+
+## Controller State Requests
+
+The network stack can now request rover state changes from controller packets.
+The intended mapping is:
+
+- hold `SELECT` (`SCB`) for at least 0.5s
+- while still holding it:
+  - `Y / N` -> `TELEOP`
+  - `B / E` -> `AUTO`
+  - `X / W` -> `IDLE`
+
+The Go server writes one-shot requests to `/tmp/rover_state_request`, and
+`Rover/main.c` consumes that file in its main loop before updating
+`/tmp/rover_state`.
 
 ## Quick Test Flow
 

--- a/Server-Pi/Rover/main.c
+++ b/Server-Pi/Rover/main.c
@@ -4,6 +4,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <inttypes.h>
+#include <string.h>
 #include <sys/select.h> // lets us poll stdin without blocking the state loop
 
 
@@ -18,10 +19,12 @@ long stateStartTime = 0;
 long lastPrintTime = 0;
 
 const long printInterval = 2500; // how often to print the remaining time in milliseconds, in this case every second
+const char *stateRequestPath = "/tmp/rover_state_request";
 
 // Forward declare changeState because the input helper can trigger transitions.
 
 void changeState(enum RoverState newState);
+void pollStateRequest(void);
 
 long millis() {
   struct timespec ts;
@@ -80,6 +83,30 @@ void pollStateInput(void) {
   for (ssize_t i = 0; i < bytesRead; i++) {
     handleStateCommand(inputBuffer[i]);
   }
+}
+
+void pollStateRequest(void) {
+  FILE *requestFile = fopen(stateRequestPath, "r");
+  if (requestFile == NULL) {
+    return;
+  }
+
+  char line[128];
+  if (fgets(line, sizeof(line), requestFile) != NULL) {
+    char *modeToken = strtok(line, ",\n\r");
+    if (modeToken != NULL) {
+      if (strcmp(modeToken, "IDLE") == 0) {
+        changeState(IDLE);
+      } else if (strcmp(modeToken, "TELEOP") == 0) {
+        changeState(TELEOP);
+      } else if (strcmp(modeToken, "AUTO") == 0) {
+        changeState(AUTO);
+      }
+    }
+  }
+
+  fclose(requestFile);
+  unlink(stateRequestPath);
 }
 
 void changeState(enum RoverState newState){ // newState is just another instance for the rover state in function that is used in this function to change the state
@@ -144,6 +171,7 @@ void loop() {
   long now = millis(); //how long the program has been running minus the time when the state started which atp is 0 with stateStartTime updated every time the state changes.
   // Poll once per loop so state transitions can be triggered interactively.
   pollStateInput();
+  pollStateRequest();
 
   switch(currentState){
     case IDLE:


### PR DESCRIPTION
## Summary
- add the operator GUI dashboard and setup docs for local and Raspberry Pi proxy workflows
- switch the server default to the 8-byte teleop-oriented mapping with `LjoyY`, `RjoyY`, `LT`, and `RT`
- detect controller-driven rover mode requests on the server and hand them off to the rover FSM through `/tmp/rover_state_request`
- preserve the existing CRC32 packet logging and sequence-gap detection flow while surfacing state requests in the GUI

## Verification
- `env GOCACHE=/tmp/go-build-cache go build .` in `Server-Pi/Network-Stack`
- `python3 -m py_compile dashboard.py` in `Client-PC/GUI`
- `cc -std=c11 -Wall -Wextra -pedantic -o /tmp/rover_fsm_test main.c` in `Server-Pi/Rover`

Refs #5